### PR TITLE
Npc

### DIFF
--- a/permute/irr.py
+++ b/permute/irr.py
@@ -152,7 +152,7 @@ def simulate_ts_dist(ratings, obs_ts = None, iter=10000, keep_dist = False):
 
 
 
-def simulate_npc_dist(ratings, obs_ts = None, iter=10000, keep_dist = False):
+def simulate_npc_dist(perm_distr, size, obs_npc = None, pvalues = None, keep_dist = False):
     """
     Simulates the permutation distribution of the combined irr test statistic 
     for S matrices of ratings <ratings> corresponding to S strata
@@ -166,15 +166,24 @@ def simulate_npc_dist(ratings, obs_ts = None, iter=10000, keep_dist = False):
 
     Parameters
     ----------
-    ratings : array_like
-              Input array of dimension [R, Ns]
-
-    obs_ts : float
-             if None, obs_ts is calculated as the value of the test statistic for the
+    perm_distr : array_like
+                 Input array of dimension [B, S]
+                 Column s is the permutation distribution of rho_s, for s=1,...,S
+             
+    size: array_like
+             Input array of dimension S
+             Each entry corresponds to the number of items, Ns,
+             in the s-th stratum.   
+                              
+    obs_npc : float
+             if None, obs_npc is calculated as the value of the test statistic for the
              original data
-
-    iter : integer
-           number of random permutation of the elements of each row of ratings
+             
+    pvalues: array_like
+             Input array of dimension S
+             Each entry corresponds to the p-value for rho_s, the 
+             concordance for the s-th stratum.
+      
 
     keep_dist : bool
                 flag for whether to store and return the array of values of the irr
@@ -186,31 +195,38 @@ def simulate_npc_dist(ratings, obs_ts = None, iter=10000, keep_dist = False):
     out : {obs_ts, geq, iter, dist}
     obs_ts : observed value of the test statistic for the input data, or the input value
              of obs_ts if obs_ts was given as input
-    geq : number of iterations for which the test statistic was greater than or equal to
-          obs_ts
+    leq : number of iterations for which the NPC test statistic was less than or equal to
+          obs_npc
     iter : iter
     dist : if <keep_dist>, the array of values of the irr test statistic from the iter
            iterations.  Otherwise, null.
     """
-    r = ratings.copy()
-
-    if obs_ts is None:
-        obs_ts = compute_ts(r)
 
 
+    # Throw an error if both obs_npc and pvalues are None
+    
+    if obs_npc is None:
+        obs_npc = compute_inverseweight_npc(pvalues, size)
+
+    r = perm_distr.copy()
+    r = np.sort(r, axis = 0)
+    (B, S) = r.shape
+    
     if keep_dist:
-        dist = np.zeros(iter)
-        for i in range(iter):
-            for row in r:
-                np.random.shuffle(row)
-            dist[i] = compute_ts(r)
-        geq = np.sum(dist >= obs_ts)
+        dist = np.zeros(B)
+        p = np.zeros((S,1))
+        for i in range(B):
+            for j in range(S):
+                p[j] = np.searchsorted(r[:,j], perm_distr[i,j])/B
+            dist[i] = compute_inverseweight_npc(p, size)
+        leq = np.sum(dist <= obs_npc)
     else:
         dist = None
-        geq = 0
-        for i in range(iter):
-            for row in r:
-                np.random.shuffle(row)            
-            geq += (compute_ts(r) >= obs_ts)
-    return {"obs_ts": obs_ts, "geq": geq, "iter": iter, "dist": dist}
+        p = np.zeros((S,1))
+        leq = 0
+        for i in range(B):
+            for j in range(S):
+                p[j] = np.searchsorted(r[:,j], perm_distr[i,j])/B
+            leq += (compute_inverseweight_npc(p, size) <= obs_npc)
+    return {"obs_npc": obs_npc, "leq": leq, "iter": B, "dist": dist}
 

--- a/permute/irr.py
+++ b/permute/irr.py
@@ -154,7 +154,7 @@ def simulate_ts_dist(ratings, obs_ts = None, iter=10000, keep_dist = False):
 
 def simulate_npc_dist(perm_distr, size, obs_npc = None, pvalues = None, keep_dist = False):
     """
-    Simulates the permutation distribution of the combined irr test statistic 
+    Simulates the permutation distribution of the combined NPC test statistic 
     for S matrices of ratings <ratings> corresponding to S strata
 
     If obs_ts is not null, computes the reference value of the test statistic before
@@ -193,12 +193,12 @@ def simulate_npc_dist(perm_distr, size, obs_npc = None, pvalues = None, keep_dis
     Returns
     -------
     out : {obs_ts, geq, iter, dist}
-    obs_ts : observed value of the test statistic for the input data, or the input value
+    obs_npc : observed value of the test statistic for the input data, or the input value
              of obs_ts if obs_ts was given as input
     leq : number of iterations for which the NPC test statistic was less than or equal to
           obs_npc
-    iter : iter
-    dist : if <keep_dist>, the array of values of the irr test statistic from the iter
+    iter : B
+    dist : if <keep_dist>, the array of values of the NPC test statistic from the iter
            iterations.  Otherwise, null.
     """
 

--- a/permute/tests/test_irr.py
+++ b/permute/tests/test_irr.py
@@ -1,4 +1,4 @@
-from ..irr import compute_ts, simulate_ts_dist
+from ..irr import compute_ts, simulate_ts_dist, compute_inverseweight_npc
 #from nose.tools import assert_almost_equal
 
 import numpy as np
@@ -51,3 +51,12 @@ def test_simulate_ts_dist_concordance():
                     'iter': 10000}
     res_conc = simulate_ts_dist(res2)
     assert_equal(res_conc, expected_res_conc)
+    
+    
+    
+pval = np.array([0.5, 0.25, 0.75])
+size = np.array([2, 4, 6])
+def test_compute_inverseweight_npc():
+    expected_npc = 0.7847396
+    res_npc = compute_inverseweight_npc(pval, size)
+    assert_almost_equal(expected_npc, res_npc)

--- a/permute/tests/test_irr.py
+++ b/permute/tests/test_irr.py
@@ -1,4 +1,4 @@
-from ..irr import compute_ts, simulate_ts_dist, compute_inverseweight_npc
+from ..irr import compute_ts, simulate_ts_dist, compute_inverseweight_npc, simulate_npc_dist
 #from nose.tools import assert_almost_equal
 
 import numpy as np
@@ -60,3 +60,20 @@ def test_compute_inverseweight_npc():
     expected_npc = 0.7847396
     res_npc = compute_inverseweight_npc(pval, size)
     assert_almost_equal(expected_npc, res_npc)
+ 
+ 
+    
+np.random.seed(100)
+res1 = simulate_ts_dist(res, keep_dist = True)
+res_conc = simulate_ts_dist(res2, keep_dist = True)
+true_pvalue = np.array([ res1['geq']/res1['iter'], res_conc['geq']/res_conc['iter']])
+rho_perm = np.transpose(np.vstack((res1['dist'], res_conc['dist'])))
+
+@np.testing.decorators.skipif(True)
+def test_simulate_npc_dist():
+    expected_npc_res = {'dist': None,
+                        'iter': 10000,
+                        'leq': 9,
+                        'obs_npc':  0.010479912758633605}
+    obs_npc_res = simulate_npc_dist(rho_perm, size = np.array([Ns, Ns]), pvalues = true_pvalue)
+    assert_equal(obs_npc_res, expected_npc_res)


### PR DESCRIPTION
I added 2 functions. The first one computes the combined test statistic, weighting the s-th p-value by 1/sqrt(N_s) and summing them up. The second function takes the permutation distributions obtained from each stratum and uses them to calibrate the p-value of the combined test statistic.

There is an example of how to use the NPC test function in the test_irr.py file.