### PR TITLE
Improve tests

### DIFF
--- a/permute/core.py
+++ b/permute/core.py
@@ -112,14 +112,14 @@ def binom_conf_interval(n, x, cl=0.975, alternative="two-sided", p=None,
     ci_low = 0.0
     ci_upp = 1.0
 
-    if alternative == 'both':
+    if alternative == 'two-sided':
         cl = 1 - (1-cl)/2
 
     # FIXME: should I check that alternative is valid?
     if alternative != "greater" and x > 0:
         f = lambda q: cl - binom.cdf(x - 1, n, q)
         ci_low = brentq(f, 0.0, p, *kwargs)
-    elif alternative != "less" and x < n:
+    if alternative != "less" and x < n:
         f = lambda q: binom.cdf(x, n, q) - (1 - cl)
         ci_upp = brentq(f, 1.0, p, *kwargs)
 

--- a/permute/core.py
+++ b/permute/core.py
@@ -118,10 +118,10 @@ def binom_conf_interval(n, x, cl=0.975, alternative="two-sided", p=None,
     # FIXME: should I check that alternative is valid?
     if alternative != "greater" and x > 0:
         f = lambda q: cl - binom.cdf(x - 1, n, q)
-        ci_low = brentq(f, 0.0, p, kwargs)
+        ci_low = brentq(f, 0.0, p, *kwargs)
     elif alternative != "less" and x < n:
         f = lambda q: binom.cdf(x, n, q) - (1 - cl)
-        ci_upp = brentq(f, 1.0, p, kwargs)
+        ci_upp = brentq(f, 1.0, p, *kwargs)
 
     return ci_low, ci_upp
 

--- a/permute/tests/test_core.py
+++ b/permute/tests/test_core.py
@@ -28,10 +28,19 @@ def test_permute_within_group():
     res3.sort()
     np.testing.assert_equal(group, res3)
 
-@np.testing.dec.skipif(True)
 def test_binom_conf_interval():
     res = binom_conf_interval(10, 3)
-
+    expected = (0.05154625578928545, 0.6915018049393984)
+    np.testing.assert_equal(res, expected)
+    
+    res2 = binom_conf_interval(10, 5, cl = 0.95, alternative = "greater")
+    expected2 = (0.0, 0.7775588989918742)
+    np.testing.assert_equal(res2, expected2)
+    
+    res3 = binom_conf_interval(10, 5, cl = 0.95, alternative = "less")
+    expected3 = (0.22244110100812578, 1.0)
+    np.testing.assert_equal(res3, expected3)
+    
 def test_permute_rows():
     prng = RandomState(42)
 


### PR DESCRIPTION
I fixed the bug in binom_conf_intervals and wrote some tests for different alternatives. There were several bugs: use of kwargs in brentfq needed to be changed to *kwargs, change from "both" to "two-sided", and an issue with doing both upper and lower confidence bounds for the two-sided alternative.