### PR TITLE
WIP: restructuring

### DIFF
--- a/permute/core.py
+++ b/permute/core.py
@@ -15,62 +15,6 @@ from scipy.stats import (binom, ttest_ind)
 from .utils import get_prng
 
 
-def permute_within_groups(x, group, seed=None):
-    """
-    Permutation of condition within each group.
-
-    Parameters
-    ----------
-    x : array-like
-        A 1-d array indicating treatment.
-    group : array-like
-        A 1-d array indicating group membership
-    seed : RandomState instance or {None, int, RandomState instance}
-        If None, the pseudorandom number generator is the RandomState
-        instance used by `np.random`;
-        If int, seed is the seed used by the random number generator;
-        If RandomState instance, seed is the pseudorandom number generator
-
-    Returns
-    -------
-    permuted : array-like
-        The within group permutation of x.
-    """
-    prng = get_prng(seed)
-    permuted = x.copy()
-
-    # (avoid additional flops) -- maybe memoize
-    for g in np.unique(group):
-        gg = group == g
-        permuted[gg] = prng.permutation(permuted[gg])
-    return permuted
-
-
-def permute_rows(m, seed=None):
-    """
-    Permute the rows of a matrix in-place
-
-    Parameters
-    ----------
-    m : array-like
-        A 2-d array
-    seed : RandomState instance or {None, int, RandomState instance}
-        If None, the pseudorandom number generator is the RandomState
-        instance used by `np.random`;
-        If int, seed is the seed used by the random number generator;
-        If RandomState instance, seed is the pseudorandom number generator
-
-    Returns
-    -------
-    None
-        Original matrix is permute in-place, nothing returned
-    """
-    prng = get_prng(seed)
-
-    for row in m:
-        prng.shuffle(row)
-
-
 def corr(x, y, reps=10**4, seed=None):
     """
     Simulate permutation p-value for Spearman correlation coefficient

--- a/permute/irr.py
+++ b/permute/irr.py
@@ -67,8 +67,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from .core import permute_rows
-from .utils import get_prng
+from .utils import get_prng, permute_rows
 
 
 def compute_ts(ratings):

--- a/permute/stratified.py
+++ b/permute/stratified.py
@@ -8,8 +8,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from .core import permute_within_groups
-from .utils import get_prng
+from .utils import get_prng, permute_within_groups
 
 
 def corrcoef(x, y, group):

--- a/permute/tests/test_core.py
+++ b/permute/tests/test_core.py
@@ -8,27 +8,7 @@ from numpy.random import RandomState
 
 from ..core import (binom_conf_interval,
                     corr,
-                    permute_within_groups,
-                    permute_rows,
                     two_sample)
-
-
-def test_permute_within_group():
-    x = np.repeat([1, 2, 3]*3, 3)
-    group = np.repeat([1, 2, 3], 9)
-    #response = np.zeros_like(group)
-    #response[[0,  1,  3,  9, 10, 11, 18, 19, 20]] = 1
-
-    prng1 = RandomState(42)
-    prng2 = RandomState(42)
-    res1 = permute_within_groups(x, group, prng1)
-    res2 = permute_within_groups(x, group, prng2)
-    np.testing.assert_equal(res1, res2)
-
-    res3 = permute_within_groups(x, group)
-    np.testing.assert_equal(res3.max(), 3)
-    res3.sort()
-    np.testing.assert_equal(group, res3)
 
 
 def test_corr():
@@ -67,20 +47,6 @@ def test_binom_conf_interval():
     res3 = binom_conf_interval(10, 5, cl=0.95, alternative="lower")
     expected3 = (0.22244110100812578, 1.0)
     np.testing.assert_equal(res3, expected3)
-
-
-def test_permute_rows():
-    prng = RandomState(42)
-
-    x = prng.randint(10, size=20).reshape(2, 10)
-    permute_rows(x, prng)
-    expected = np.array([[2, 7, 7, 6, 4, 9, 3, 4, 6, 6],
-                         [7, 4, 5, 5, 3, 7, 1, 2, 7, 1]])
-    np.testing.assert_array_equal(x, expected)
-
-    permute_rows(x)
-    np.testing.assert_equal(x.max(), 9)
-    np.testing.assert_equal(x.min(), 1)
 
 
 @attr('slow')

--- a/permute/tests/test_utils.py
+++ b/permute/tests/test_utils.py
@@ -4,7 +4,9 @@ import numpy as np
 from numpy.random import RandomState
 from numpy.testing import assert_equal
 
-from ..utils import get_prng
+from ..utils import (get_prng,
+                     permute_rows,
+                     permute_within_groups)
 
 
 def test_get_random_state():
@@ -37,3 +39,35 @@ def test_get_random_state():
 @raises(ValueError)
 def test_get_random_state_error():
     get_prng(1.11)
+
+
+def test_permute_within_group():
+    x = np.repeat([1, 2, 3]*3, 3)
+    group = np.repeat([1, 2, 3], 9)
+    #response = np.zeros_like(group)
+    #response[[0,  1,  3,  9, 10, 11, 18, 19, 20]] = 1
+
+    prng1 = RandomState(42)
+    prng2 = RandomState(42)
+    res1 = permute_within_groups(x, group, prng1)
+    res2 = permute_within_groups(x, group, prng2)
+    np.testing.assert_equal(res1, res2)
+
+    res3 = permute_within_groups(x, group)
+    np.testing.assert_equal(res3.max(), 3)
+    res3.sort()
+    np.testing.assert_equal(group, res3)
+
+
+def test_permute_rows():
+    prng = RandomState(42)
+
+    x = prng.randint(10, size=20).reshape(2, 10)
+    permute_rows(x, prng)
+    expected = np.array([[2, 7, 7, 6, 4, 9, 3, 4, 6, 6],
+                         [7, 4, 5, 5, 3, 7, 1, 2, 7, 1]])
+    np.testing.assert_array_equal(x, expected)
+
+    permute_rows(x)
+    np.testing.assert_equal(x.max(), 9)
+    np.testing.assert_equal(x.min(), 1)

--- a/permute/utils.py
+++ b/permute/utils.py
@@ -30,3 +30,61 @@ def get_prng(seed=None):
         return seed
     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
                      ' instance' % seed)
+
+
+def permute_within_groups(x, group, seed=None):
+    """
+    Permutation of condition within each group.
+
+    Parameters
+    ----------
+    x : array-like
+        A 1-d array indicating treatment.
+    group : array-like
+        A 1-d array indicating group membership
+    seed : RandomState instance or {None, int, RandomState instance}
+        If None, the pseudorandom number generator is the RandomState
+        instance used by `np.random`;
+        If int, seed is the seed used by the random number generator;
+        If RandomState instance, seed is the pseudorandom number generator
+
+    Returns
+    -------
+    permuted : array-like
+        The within group permutation of x.
+    """
+    prng = get_prng(seed)
+    permuted = x.copy()
+
+    # (avoid additional flops) -- maybe memoize
+    for g in np.unique(group):
+        gg = group == g
+        permuted[gg] = prng.permutation(permuted[gg])
+    return permuted
+
+
+def permute_rows(m, seed=None):
+    """
+    Permute the rows of a matrix in-place
+
+    Parameters
+    ----------
+    m : array-like
+        A 2-d array
+    seed : RandomState instance or {None, int, RandomState instance}
+        If None, the pseudorandom number generator is the RandomState
+        instance used by `np.random`;
+        If int, seed is the seed used by the random number generator;
+        If RandomState instance, seed is the pseudorandom number generator
+
+    Returns
+    -------
+    None
+        Original matrix is permute in-place, nothing returned
+    """
+    prng = get_prng(seed)
+
+    for row in m:
+        prng.shuffle(row)
+
+


### PR DESCRIPTION
While trying to describe what each module's purpose is, I started thinking about reshuffling a few things.  Generic functions (like the permute_X) will go in permute.utils.  I was also thinking about renaming core to something like simple.  We are putting non-stratified tests and confidence sets in there now.  I don't know what the best name for non-stratified tests is.  Maybe simple isn't the right name either, so I am open for ideas.