### PR TITLE
MRG: Two sample bugfix

### DIFF
--- a/permute/core.py
+++ b/permute/core.py
@@ -201,9 +201,9 @@ def two_sample(x, y, reps=10**5, stat='mean', alternative="greater",
 
     tst = theStat[alternative](z)
     if keep_dist:
-        dist = []
+        dist = np.empty(reps)
         for i in range(reps):
-            dist.append(theStat[alternative](prng.permutation(z)))
+            dist[i] = theStat[alternative](prng.permutation(z))
         hits = np.sum(dist >= tst)
         if interval in ["upper", "lower", "two-sided"]:
             return (hits/reps, tst,

--- a/permute/tests/test_core.py
+++ b/permute/tests/test_core.py
@@ -63,8 +63,10 @@ def test_two_sample():
 
     y = prng.normal(1.4, size=20)
     res = two_sample(x, y, seed=42)
+    res2 = two_sample(x, y, seed=42, keep_dist=True)
     expected = (0.96975, -0.54460818906623765)
     np.testing.assert_equal(res, expected)
+    np.testing.assert_equal(res2[:2], expected)
 
     y = prng.normal(1, size=20)
     res = two_sample(x, y, seed=42)


### PR DESCRIPTION
I was working on the MacNell et. al. reanalysis and noticed I got different p-values running two_sample with keep_dist = True vs keep_dist = False.