### PR TITLE
BUG: remove unnecessary apt-get call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - source venv/bin/activate
   - python --version
   - pip install --upgrade pip
-  - sudo apt-get install libblas-dev liblapack-dev libatlas3gf-base
   - wheelhouse_pip_r_install ${DEPENDS}
 
 install:


### PR DESCRIPTION
We should be using wheels for everything, so no need for dev libraries.