### PR TITLE
Update core.py

### DIFF
--- a/permute/core.py
+++ b/permute/core.py
@@ -601,9 +601,9 @@ def one_sample(x, y=None, reps=10**5, stat='mean', alternative="greater",
     tst = tst_fun(z)
     n = len(z)
     if keep_dist:
-        dist = []
+        dist = np.empty(reps)
         for i in range(reps):
-            dist.append(tst_fun(z * (1 - 2 * prng.randint(0, 2, n))))
+            dist[i] = tst_fun(z * (1 - 2 * prng.randint(0, 2, n)))
         hits = np.sum(dist >= tst)
         return thePvalue[alternative](hits / (reps+plus1)), tst, dist
     else:


### PR DESCRIPTION
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-232-c59af64c5d86> in <module>
      1 one_sample_test = one_sample(x=diff_score, reps=100000, 
----> 2                          stat='mean', alternative='two-sided', keep_dist=True, seed=10)

D:\Softwares\Anaconda3\envs\tf2\lib\site-packages\permute\core.py in one_sample(x, y, reps, stat, alternative, keep_dist, seed, plus1)
    603         for i in range(reps):
    604             dist.append(tst_fun(z * (1 - 2 * prng.randint(0, 2, n))))
--> 605         hits = np.sum(dist >= tst)
    606         return thePvalue[alternative](hits / (reps+plus1)), tst, dist
    607     else:

TypeError: '>=' not supported between instances of 'list' and 'float'


To remove these errors. we have to change the code. 