### PR TITLE
Drop support for Python 3.6 (see NEP 29)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: Ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -68,7 +68,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ if __name__ == "__main__":
             "Intended Audience :: Science/Research",
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
@@ -83,7 +82,7 @@ if __name__ == "__main__":
         ],
         install_requires=INSTALL_REQUIRES,
         tests_require=TESTS_REQUIRE,
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         packages=["permute", "permute.tests", "permute.data", "permute.data.tests"],
         package_data={"permute.data": ["*.csv", "*/*.csv", "*/*/*.csv"]},
     )


### PR DESCRIPTION
@pbstark @akglazer The scientific Python ecosystem is trying to coordinate minimum Python version support.  This is one of the first steps we are taking as a community to better unify the various separate projects that exist in the ecosystem.  Several of the core packages (NumPy, SciPy, matplotlib, scikit-image, networkx, pandas, etc.) have all decided to drop support for Python 3.6 on their next release.

scikit-image already has a release without Python 3.6 support:
- https://pypi.org/project/scikit-image/  (Dec. 15)

NumPy, SciPy, and Pandas already have release candidates without Python 3.6 support:
- https://pypi.org/project/numpy/1.20.0rc1/  (Dec. 3)
- https://pypi.org/project/scipy/1.6.0rc1/  (Dec. 10)
- https://pypi.org/project/pandas/1.2.0rc0/  (Dec. 8)

I plan to make a NetworkX release without Python 3.6 support in a week or so.  I am not sure when Matplotlib is planning to make a new release, but they've removed support for 3.6 from master already.

Dropping Python 3.6 support isn't a huge deal, but it is an important first step in making the ecosystem more coherent.  And it reduces the work of maintainers and CI systems.  I recommend we follow NEP 29 and drop 3.6 support (which is what this PR does).

For more information see:
https://numpy.org/neps/nep-0029-deprecation_policy.html