### PR TITLE
Upper bound scipy

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 numpy>=1.20
-scipy>=1.6
+scipy>=1.6,<1.7
 cryptorandom>=0.3


### PR DESCRIPTION
It looks like SciPy 1.7 made some updates that cause our tests to fail. I will merge this and we can track down the error in another PR.