### PR TITLE
Test on scipy 1.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: Ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -68,7 +68,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 numpy>=1.20
-scipy==1.7.3
+scipy==1.8.1
 cryptorandom>=0.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 numpy>=1.20
-scipy==1.8.1
+scipy==1.9.1
 cryptorandom>=0.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 numpy>=1.20
-scipy>=1.6,<1.7
+scipy==1.7.3
 cryptorandom>=0.3


### PR DESCRIPTION
SciPy 1.7 had a lot of updates to `scipy.stats` and it looks like it broke our tests. You can see the release notes here:
https://scipy.github.io/devdocs/release.1.7.0.html

I pinned to `scipy>=1.6,<1.7` in #198. So the main branch passes the CI tests. You can make PRs off main (and update your existing PRs). But we should drop support for scipy 1.6 soon and figure out whether we need to update our tests or whether we are uncovering bugs in `scipy.stats`, which were introduced in 1.7.